### PR TITLE
docs: simplify support-star line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,5 +243,4 @@ Apache 2.0 -- see [LICENSE](LICENSE).
 
 ## Support Trajectly
 
-If Trajectly is useful to your work, please give the repository a star ⭐:
-<https://github.com/trajectly/trajectly/stargazers>
+If Trajectly is useful to your work, please give the repository a star ⭐


### PR DESCRIPTION
This PR only updates the final support line in the README to remove the explicit stargazers URL.

Change:
- Replace:
  - `If Trajectly is useful to your work, please give the repository a star ⭐:`
  - `<https://github.com/trajectly/trajectly/stargazers>`
- With:
  - `If Trajectly is useful to your work, please give the repository a star ⭐`
