### PR TITLE
docs: restructure positioning around 6 failure categories and arena examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,91 +4,106 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/trajectly/trajectly/badge)](https://securityscorecards.dev/viewer/?uri=github.com/trajectly/trajectly)
 [![PyPI version](https://img.shields.io/pypi/v/trajectly.svg)](https://pypi.org/project/trajectly/)
 
-Trajectly is deterministic regression testing for AI agents.
+Deterministic regression testing for AI agents.
 
-It catches behavior regressions that output-only checks often miss:
-- missing required tool calls
-- wrong call order
-- denied network/tool usage
-- argument and budget-policy violations
-
-Trajectly reports a deterministic witness index and a reproducible failing command.
+The answer looked fine. The behavior wasn't. An agent that skips approval, leaks a secret, or calls a forbidden domain can still produce a perfectly worded final answer. Trajectly catches the behavioral regression and tells you *exactly where it broke*.
 
 ## Install
 
 ```bash
-python -m pip install trajectly
-python -m trajectly --version
+pip install trajectly
 ```
 
 ## 30-Second Quickstart
 
-Use arena scenarios with committed fixtures (no API keys required):
+Uses committed fixtures -- no API keys required.
 
 ```bash
 git clone https://github.com/trajectly/trajectly-survival-arena.git
 cd trajectly-survival-arena
-python3.11 -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
 python -m trajectly init
 
 # baseline behavior (expected PASS)
 python -m trajectly run specs/challenges/procurement-chaos.agent.yaml --project-root .
 
-# intentional regression behavior (expected FAIL)
+# intentional regression (expected FAIL -- approval was skipped)
 python -m trajectly run specs/examples/procurement-chaos-regression.agent.yaml --project-root .
 python -m trajectly report
 python -m trajectly repro
 python -m trajectly shrink
 ```
 
-Expected exits for this flow:
-- safe `run` -> `0`
-- regression `run` -> `1`
-- `report` -> `0`
-- `repro` -> `1`
-- `shrink` -> `0`
+## What Trajectly Catches
 
-Stable output cues:
+Six categories of silent failure that correct-looking output can hide.
+
+### Missing steps
+
+An agent skips a required step but the answer reads fine. Trajectly extracts a tool-call skeleton from the baseline and verifies it appears as a subsequence in the current trace. Missing calls break the skeleton.
 
 ```text
-# safe run
-- `procurement-chaos`: clean
-  - trt: `PASS`
-
-# regression run
-- `procurement-chaos`: regression
-  - trt: `FAIL` (witness=...)
-
-# report
-Source: $PROJECT_ROOT/.trajectly/reports/latest.md
+REFINEMENT_BASELINE_CALL_MISSING — missing_call=route_for_approval — witness=6
 ```
 
-The canonical onboarding flow lives in [docs/trajectly_guide.md](docs/trajectly_guide.md).
+### Wrong order
 
-## What Trajectly Checks
+The right tools called in the wrong sequence. `require_before` says "A must happen before B" without locking exact positions, so the agent can evolve without breaking the ordering rule.
 
-1. Contracts: tools, sequence, network, data leak, args, budgets.
-2. Refinement: baseline tool-call skeleton remains a subsequence of current behavior.
-3. Witness resolution: earliest failing trace event index.
+```text
+CONTRACT_SEQUENCE_REQUIRE_BEFORE_VIOLATED — expected=reserve_room before send_invite — witness=4
+```
+
+### Leaked secrets
+
+The summary looks clean but the outbound tool-call payload contains a secret pattern. Trajectly scans outbound arguments against regex patterns declared in the contract.
+
+```text
+DATA_LEAK_SECRET_PATTERN — pattern=sk_live_[A-Za-z0-9]+ — witness=4
+```
+
+### Forbidden network access
+
+The agent reports success but contacted a domain outside the allowlist. The network contract defaults to deny-all and whitelists specific domains.
+
+```text
+NETWORK_DOMAIN_DENIED — witness=2
+```
+
+### Invalid arguments
+
+A tool call completes but an argument violates its format. Argument contracts validate required keys, types, numeric bounds, regex patterns, and enum values on every call.
+
+```text
+CONTRACT_ARGS_REGEX_VIOLATION — witness=6
+```
+
+### Budget overruns
+
+Identical output, but twice the tool calls or tokens. Budget thresholds gate execution cost at the spec level.
+
+```text
+budget_breach — max_tool_calls exceeded
+```
+
+## How You Debug Failures
+
+Every failure comes with three tools:
+
+| Tool | What it does | Command |
+|---|---|---|
+| **Witness** | Pinpoints the exact trace event where behavior diverged | Included in every report |
+| **Repro** | Replays the exact failure deterministically | `python -m trajectly repro` |
+| **Shrink** | Reduces the trace to the shortest proof (14 events -> 3) | `python -m trajectly shrink` |
+
+No log hunting. No guesswork. No LLM calls for evaluation.
 
 ## Use This In Your Project
 
-Minimal migration recipe:
-
-1. Make your agent command deterministic enough to replay.
-2. Add one `.agent.yaml` spec.
-3. Add one contract policy.
-4. Record baseline.
-5. Gate with `run`.
-6. Debug with `report`, `repro`, `shrink`.
-
-Starter files:
+1. Add one `.agent.yaml` spec:
 
 ```yaml
-# specs/my-agent.agent.yaml
 schema_version: "0.4"
 name: "my-agent"
 command: "python -m my_agent.runner"
@@ -99,15 +114,17 @@ contracts:
   config: contracts/my-agent.contracts.yaml
 ```
 
+2. Add one `.contracts.yaml` policy:
+
 ```yaml
-# contracts/my-agent.contracts.yaml
+version: v1
 tools:
   allow: [fetch_context, create_reply]
 sequence:
   require: [fetch_context, create_reply]
 ```
 
-Baseline and gate commands:
+3. Record, gate, debug:
 
 ```bash
 python -m trajectly init
@@ -123,45 +140,43 @@ python -m trajectly shrink
 Any CI:
 
 ```bash
-python -m pip install trajectly
-python -m trajectly run specs/challenges/*.agent.yaml --project-root .
+pip install trajectly
+python -m trajectly run specs/*.agent.yaml --project-root .
 python -m trajectly report --pr-comment > trajectly_pr_comment.md
 ```
 
 GitHub Actions:
 
 ```yaml
-name: Agent Regression Tests
-on: [push, pull_request]
-
-jobs:
-  trajectly:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: trajectly/trajectly-action@v1.0.1
-        with:
-          spec_glob: "specs/challenges/*.agent.yaml"
-          project_root: "."
+- uses: trajectly/trajectly-action@v1.0.1
+  with:
+    spec_glob: "specs/*.agent.yaml"
+    project_root: "."
+    comment_pr: "true"
 ```
 
-Replace `specs/challenges/*.agent.yaml` with your own spec glob/path in your project.
+When a spec fails, the PR gets a death report: witness index, violated contract, repro command, and shrink result.
+
+See [trajectly-action](https://github.com/trajectly/trajectly-action) for full CI documentation.
+
+## Try Merge or Die
+
+Eight arena scenarios covering all six failure categories. Run them, break them, debug them.
+
+[trajectly-survival-arena](https://github.com/trajectly/trajectly-survival-arena) | [trajectly.dev/merge-or-die](https://www.trajectly.dev/merge-or-die)
 
 ## Documentation
 
-- [Guide](docs/trajectly_guide.md)
-- [Reference](docs/trajectly_reference.md)
-- [CI: GitHub Actions](docs/ci_github_actions.md)
+- [Guide](docs/trajectly_guide.md) -- onboarding, core concepts, TRT algorithm
+- [What Trajectly Catches](docs/what_trajectly_catches.md) -- six failure categories with full examples
+- [Contract Catalog](docs/contract_catalog.md) -- reference for all six contract dimensions
+- [Reference](docs/trajectly_reference.md) -- CLI, spec schema, SDK, trace schema
+- [CI: GitHub Actions](docs/ci_github_actions.md) -- action inputs, execution order, artifacts
 - [Architecture (maintainers)](docs/architecture_phase1.md)
-- [Security policy](SECURITY.md)
-- [Contributing guide](CONTRIBUTING.md)
-- [Merge or Die Arena](https://github.com/trajectly/trajectly-survival-arena)
 
 ## Contributing
 
-For contribution flow and local checks, see [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/docs/ci_github_actions.md
+++ b/docs/ci_github_actions.md
@@ -4,7 +4,6 @@ The canonical Trajectly GitHub Action is:
 `trajectly/trajectly-action@v1.0.1`
 
 It wraps CLI commands and CI plumbing only. TRT evaluation remains in Python code.
-The in-repo action path `./github-action` is kept as a temporary compatibility wrapper and is planned for removal in `v0.4.3` (one release cycle after `v0.4.2`).
 
 ## Minimal workflow
 
@@ -53,9 +52,6 @@ Recommendation:
 | `comment_pr` | `false` | Post/update PR comment with report markdown (PR events only) |
 | `upload_artifacts` | `true` | Upload `${project_root}/.trajectly/**` artifact |
 
-Compatibility note:
-- The deprecated wrapper `./github-action` keeps older defaults (`install=editable`, `comment_pr=true`) to avoid breaking existing workflows.
-
 ## What the action executes
 
 In order:
@@ -75,16 +71,16 @@ In order:
 7. **Propagate exit code**
    - final step exits with run step exit code
 
-Observed run-step output cues from a fresh validation run (March 5, 2026):
+Observed run-step output from the [Merge or Die arena](https://github.com/trajectly/trajectly-survival-arena):
 
 ```text
 # passing run
-- `trt-procurement-agent`: clean
+- `procurement-chaos`: clean
   - trt: `PASS`
 
-# failing run
-- `trt-procurement-agent`: regression
-  - trt: `FAIL` (witness=10)
+# failing run (intentional regression)
+- `procurement-chaos`: regression
+  - trt: `FAIL` (witness=6)
 Tip: run `python -m trajectly repro` to reproduce, or `python -m trajectly shrink` to minimize.
 ```
 
@@ -109,7 +105,7 @@ Observed PR comment markdown produced by `trajectly report --pr-comment`:
 ## Equivalent shell flow (any CI)
 
 ```bash
-python -m pip install trajectly
+pip install trajectly
 python -m trajectly run specs/challenges/*.agent.yaml --project-root .
 python -m trajectly report --pr-comment > trajectly_pr_comment.md
 ```

--- a/docs/contract_catalog.md
+++ b/docs/contract_catalog.md
@@ -1,0 +1,218 @@
+# Contract Catalog
+
+Trajectly contracts are declarative YAML policies that enforce behavioral invariants on agent traces. A single `.contracts.yaml` file can combine any or all of the six dimensions below.
+
+All examples reference real scenarios from the [Merge or Die arena](https://github.com/trajectly/trajectly-survival-arena).
+
+---
+
+## 1. Tools (allow / deny)
+
+Controls which tool calls are permitted during execution.
+
+```yaml
+tools:
+  allow:
+    - fetch_requisition
+    - fetch_vendor_quotes
+    - route_for_approval
+    - create_purchase_order
+  deny:
+    - unsafe_direct_award
+```
+
+**What it enforces**: Only listed tools may be called. Any call to a denied tool is an immediate violation.
+
+**Violation code**: `CONTRACT_TOOL_DENIED`
+
+**Without this**: An agent can silently switch to a disallowed tool path and still produce correct-looking output. You discover the wrong tool was used only when a side effect surfaces in production.
+
+---
+
+## 2. Sequence
+
+Controls the order in which tools must be called.
+
+```yaml
+sequence:
+  require:
+    - tool:fetch_requisition
+    - tool:fetch_vendor_quotes
+    - tool:route_for_approval
+    - tool:create_purchase_order
+  require_before:
+    - before: tool:route_for_approval
+      after: tool:create_purchase_order
+  at_most_once:
+    - tool:send_invite
+  never:
+    - tool:run_dangerous_command
+```
+
+**Directives**:
+
+| Directive | Meaning |
+|---|---|
+| `require` | These tools must appear in this order (as a subsequence -- other calls can be interleaved) |
+| `require_before` | Tool A must appear before tool B, without requiring exact positions |
+| `at_most_once` | Tool may be called at most one time |
+| `never` | Tool must never appear in the trace |
+
+**Violation codes**: `CONTRACT_SEQUENCE_REQUIRE_BEFORE_VIOLATED`, `CONTRACT_SEQUENCE_AT_MOST_ONCE_VIOLATED`, `CONTRACT_SEQUENCE_NEVER_VIOLATED`
+
+**Without this**: An agent that sends invites before reserving a room, or calls a forbidden command while still reporting "audit complete", passes any output-only check.
+
+---
+
+## 3. Network
+
+Controls which external domains the agent may contact.
+
+```yaml
+network:
+  default: deny
+  allow_domains:
+    - status.internal.example
+```
+
+**What it enforces**: All outbound network requests are checked against the domain allowlist. The default policy is deny-all, so only explicitly listed domains are reachable.
+
+**Violation code**: `NETWORK_DOMAIN_DENIED`
+
+**Without this**: An agent can exfiltrate data to an unauthorized domain or fetch from an untrusted source while its final answer looks perfectly normal.
+
+---
+
+## 4. Data Leak
+
+Scans outbound tool-call payloads for secret-like patterns.
+
+```yaml
+data_leak:
+  outbound_kinds:
+    - TOOL_CALL
+  secret_patterns:
+    - "sk_live_[A-Za-z0-9_]+"
+```
+
+**What it enforces**: Every outbound tool-call argument is matched against the declared regex patterns. If a match is found, the trace fails at the exact event.
+
+**Violation code**: `DATA_LEAK_SECRET_PATTERN`
+
+**Without this**: A log summarizer can produce a clean, readable summary while the raw `post_summary` payload leaks API keys, tokens, or PII to an external system.
+
+---
+
+## 5. Arguments
+
+Validates tool-call arguments against type, format, and value constraints.
+
+```yaml
+args:
+  dispatch_war_room:
+    required_keys:
+      - dispatch_token
+    fields:
+      dispatch_token:
+        type: string
+        regex: "^WR-[0-9]{5}$"
+  create_purchase_order:
+    required_keys:
+      - amount_usd
+      - approval_token
+    fields:
+      amount_usd:
+        type: number
+        max: 50000
+      approval_token:
+        type: string
+        regex: "^APR-[0-9]{6}$"
+  escalate_to_human:
+    required_keys:
+      - incident_id
+      - reason_code
+    fields:
+      incident_id:
+        type: string
+        regex: "^INC-[0-9]{6}$"
+      reason_code:
+        type: string
+        enum:
+          - duplicate_charge
+          - account_takeover
+          - data_loss
+```
+
+**Field validators**:
+
+| Validator | Meaning |
+|---|---|
+| `type` | Expected type: `string`, `number`, `boolean` |
+| `regex` | Value must match this pattern |
+| `max` | Numeric upper bound |
+| `enum` | Value must be one of the listed options |
+
+**Violation code**: `CONTRACT_ARGS_REGEX_VIOLATION`, `CONTRACT_ARGS_TYPE_VIOLATION`, `CONTRACT_ARGS_MISSING_KEY`
+
+**Without this**: A tool call can complete successfully with a malformed token, an out-of-range amount, or a missing required field -- and nothing downstream catches the silent corruption.
+
+---
+
+## 6. Budget Thresholds
+
+Caps execution cost at the spec level.
+
+```yaml
+# Declared in the .agent.yaml spec, not the contracts file
+budget_thresholds:
+  max_tool_calls: 3
+  max_tokens: 500
+```
+
+**What it enforces**: If the agent exceeds the declared tool-call or token limit, Trajectly flags the run as a budget breach regression.
+
+**Classification**: `budget_breach`
+
+**Without this**: Identical final output can mask a run that made twice the API calls or consumed twice the tokens. Cost regressions are invisible until the bill arrives.
+
+---
+
+## Combining dimensions
+
+A single contracts file can use any combination of the above:
+
+```yaml
+version: v1
+tools:
+  allow: [fetch_requisition, fetch_vendor_quotes, route_for_approval, create_purchase_order]
+  deny: [unsafe_direct_award]
+sequence:
+  require:
+    - tool:fetch_requisition
+    - tool:fetch_vendor_quotes
+    - tool:route_for_approval
+    - tool:create_purchase_order
+  require_before:
+    - before: tool:route_for_approval
+      after: tool:create_purchase_order
+args:
+  create_purchase_order:
+    required_keys: [amount_usd, approval_token]
+    fields:
+      amount_usd:
+        type: number
+        max: 50000
+      approval_token:
+        type: string
+        regex: "^APR-[0-9]{6}$"
+```
+
+This single file enforces which tools can be called, in what order, and with what arguments -- all evaluated deterministically at CI time.
+
+---
+
+## See also
+
+- [What Trajectly Catches](what_trajectly_catches.md) -- six failure categories with full walkthrough examples
+- [Trajectly Reference](trajectly_reference.md) -- complete spec and contract schema
+- [Merge or Die arena](https://github.com/trajectly/trajectly-survival-arena) -- 8 runnable scenarios using all contract dimensions

--- a/docs/what_trajectly_catches.md
+++ b/docs/what_trajectly_catches.md
@@ -1,0 +1,322 @@
+# What Trajectly Catches
+
+Trajectly enforces six categories of behavioral contract and provides three debugging tools for every failure. This document walks through each one with real examples from the [Merge or Die arena](https://github.com/trajectly/trajectly-survival-arena).
+
+Every example below uses committed fixtures and runs without API keys.
+
+---
+
+## Six categories of silent failure
+
+These are regressions that produce correct-looking final text while the actual behavior is broken.
+
+### 1. Missing steps
+
+**The problem**: An agent skips a required step -- but the final answer still reads fine. A procurement agent that skips approval and goes straight to purchase order creation will still output "Purchase order created." Nothing in the text reveals the missing step.
+
+**The contract**:
+
+```yaml
+# contracts/procurement-chaos.contracts.yaml
+version: v1
+tools:
+  allow:
+    - fetch_requisition
+    - fetch_vendor_quotes
+    - route_for_approval
+    - create_purchase_order
+  deny:
+    - unsafe_direct_award
+sequence:
+  require:
+    - tool:fetch_requisition
+    - tool:fetch_vendor_quotes
+    - tool:route_for_approval
+    - tool:create_purchase_order
+  require_before:
+    - before: tool:route_for_approval
+      after: tool:create_purchase_order
+```
+
+**What Trajectly reports**:
+
+```text
+- `procurement-chaos`: regression
+  - trt: `FAIL` (witness=6)
+  - code: REFINEMENT_BASELINE_CALL_MISSING
+  - detail: missing_call=route_for_approval
+```
+
+Trajectly extracts a tool-call skeleton from the baseline and verifies it appears as a subsequence in the current trace. When `route_for_approval` is missing, the skeleton breaks and refinement catches it -- even if the agent added other calls around the gap.
+
+**Arena scenarios**: `procurement-chaos`, `support-apocalypse`, `shell-roulette`
+
+---
+
+### 2. Wrong order
+
+**The problem**: An agent calls the right tools but in the wrong order. A calendar agent that sends an invite before reserving the room will still output "Meeting arranged." The text gives no hint that the room might not be available when participants arrive.
+
+**The contract**:
+
+```yaml
+# contracts/calendar-thunderdome.contracts.yaml
+version: v1
+tools:
+  allow:
+    - lookup_oncall
+    - reserve_room
+    - send_invite
+sequence:
+  require:
+    - tool:lookup_oncall
+    - tool:reserve_room
+    - tool:send_invite
+  require_before:
+    - before: tool:reserve_room
+      after: tool:send_invite
+  at_most_once:
+    - tool:send_invite
+```
+
+**What Trajectly reports**:
+
+```text
+- `calendar-thunderdome`: regression
+  - trt: `FAIL` (witness=4)
+  - code: CONTRACT_SEQUENCE_REQUIRE_BEFORE_VIOLATED
+  - detail: expected=reserve_room before send_invite
+```
+
+The `require_before` directive says "A must happen before B" without locking exact positions. The agent can add steps between A and B, but B must never fire first.
+
+**Arena scenario**: `calendar-thunderdome`
+
+---
+
+### 3. Leaked secrets
+
+**The problem**: An agent's final summary looks clean, but the raw payload of an outbound tool call contains secret-like values. A log summarizer can produce a perfectly readable summary while the `post_summary` call body leaks an API key.
+
+**The contract**:
+
+```yaml
+# contracts/secret-karaoke.contracts.yaml
+version: v1
+tools:
+  allow:
+    - fetch_logs
+    - post_summary
+sequence:
+  require:
+    - tool:fetch_logs
+    - tool:post_summary
+data_leak:
+  outbound_kinds:
+    - TOOL_CALL
+  secret_patterns:
+    - "sk_live_[A-Za-z0-9_]+"
+```
+
+**What Trajectly reports**:
+
+```text
+- `secret-karaoke`: regression
+  - trt: `FAIL` (witness=4)
+  - code: DATA_LEAK_SECRET_PATTERN
+  - detail: pattern=sk_live_[A-Za-z0-9]+
+```
+
+Trajectly scans outbound tool-call arguments for regex-matched secret patterns. Without this, an agent can pass every test while quietly exfiltrating credentials.
+
+**Arena scenario**: `secret-karaoke`
+
+---
+
+### 4. Forbidden network access
+
+**The problem**: An agent reports success but quietly reached out to a domain it should never contact. An HTTP tool that fetches from `evil.example` instead of `status.internal.example` will still return data -- the agent just used the wrong source.
+
+**The contract**:
+
+```yaml
+# contracts/network-no-fly-zone.contracts.yaml
+version: v1
+tools:
+  allow:
+    - http_request
+sequence:
+  require:
+    - tool:http_request
+network:
+  default: deny
+  allow_domains:
+    - status.internal.example
+```
+
+**What Trajectly reports**:
+
+```text
+- `network-no-fly-zone`: regression
+  - trt: `FAIL` (witness=2)
+  - code: NETWORK_DOMAIN_DENIED
+```
+
+The network contract defaults to deny-all and whitelists specific domains. Any outbound request to an unlisted domain triggers an immediate failure with the exact event index.
+
+**Arena scenario**: `network-no-fly-zone`
+
+---
+
+### 5. Invalid arguments
+
+**The problem**: A graph of tool calls runs to completion and prints success, but a node argument silently violates its format contract. A dispatch token that should match `^WR-[0-9]{5}$` instead contains a malformed value -- and nothing downstream catches it.
+
+**The contract**:
+
+```yaml
+# contracts/graph-chain-reaction.contracts.yaml
+version: v1
+tools:
+  allow:
+    - fetch_incident
+    - dispatch_war_room
+sequence:
+  require:
+    - tool:fetch_incident
+    - tool:dispatch_war_room
+  require_before:
+    - before: tool:fetch_incident
+      after: tool:dispatch_war_room
+args:
+  dispatch_war_room:
+    required_keys:
+      - dispatch_token
+    fields:
+      dispatch_token:
+        type: string
+        regex: "^WR-[0-9]{5}$"
+```
+
+**What Trajectly reports**:
+
+```text
+- `graph-chain-reaction`: regression
+  - trt: `FAIL` (witness=6)
+  - code: CONTRACT_ARGS_REGEX_VIOLATION
+```
+
+Argument contracts validate required keys, types, numeric bounds, regex patterns, and enum values on every tool call. If a field drifts from its expected format, the violation is caught at the exact event.
+
+**Arena scenario**: `graph-chain-reaction`
+
+---
+
+### 6. Budget overruns
+
+**The problem**: The final text is identical across two runs, but the second run made twice as many tool calls or consumed twice the tokens. Cost and usage regressed silently.
+
+**The contract (in the spec)**:
+
+```yaml
+# specs/challenges/budget-gauntlet.agent.yaml
+schema_version: "0.4"
+name: "budget-gauntlet"
+command: "python -m arena.cli run --scenario budget-gauntlet"
+workdir: ../..
+fixture_policy: by_hash
+strict: false
+budget_thresholds:
+  max_tool_calls: 3
+  max_tokens: 500
+```
+
+**What Trajectly reports**:
+
+```text
+- `budget-gauntlet`: regression
+  - classification: budget_breach
+```
+
+Budget thresholds set hard limits on tool calls and token usage. When execution exceeds these limits, Trajectly flags the regression even if the TRT refinement itself passes.
+
+**Arena scenario**: `budget-gauntlet`
+
+---
+
+## Three debugging tools
+
+When a spec fails, you don't search through logs or guess what changed. Trajectly gives you three tools that form a complete debug loop.
+
+### Witness
+
+Every failure includes a **witness index** -- the exact trace event where behavior first diverged.
+
+```text
+- `procurement-chaos`: regression
+  - trt: `FAIL` (witness=6)
+```
+
+The witness points to event 6 in the trace. You don't scan the whole trace -- you go directly to the step that broke.
+
+### Repro
+
+One command replays the exact failure:
+
+```bash
+python -m trajectly repro procurement-chaos
+```
+
+This re-runs the failing spec with the same fixtures and contracts. The failure is deterministic -- same witness, same violation, every time. No environment differences, no flaky results.
+
+### Shrink
+
+One command minimizes the failing trace to its shortest proof:
+
+```bash
+python -m trajectly shrink
+```
+
+```text
+Shrink completed: 14 events -> 3 events
+```
+
+Shrink uses counterexample minimization (ddmin) to find the smallest trace that still triggers the same violation. Instead of reading 14 events, you read 3.
+
+---
+
+## The full debug loop
+
+```bash
+python -m trajectly run specs/examples/procurement-chaos-regression.agent.yaml --project-root .
+python -m trajectly report
+python -m trajectly repro
+python -m trajectly shrink
+```
+
+1. `run` gates the change (exit 0 = pass, exit 1 = regression).
+2. `report` explains why it failed (witness, violation code, detail).
+3. `repro` replays the exact failure locally.
+4. `shrink` reduces the trace to the minimal counterexample.
+
+No API keys needed. No LLM calls for evaluation. Deterministic from start to finish.
+
+---
+
+## Try it
+
+All examples above are runnable in the [trajectly-survival-arena](https://github.com/trajectly/trajectly-survival-arena):
+
+```bash
+git clone https://github.com/trajectly/trajectly-survival-arena.git
+cd trajectly-survival-arena
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python -m trajectly init
+
+python -m trajectly run specs/challenges/procurement-chaos.agent.yaml --project-root .
+python -m trajectly run specs/examples/procurement-chaos-regression.agent.yaml --project-root .
+python -m trajectly report
+python -m trajectly repro
+python -m trajectly shrink
+```


### PR DESCRIPTION
## Summary

- Rewrite README with a show-don't-tell feature showcase organized by the six categories of silent failure Trajectly catches (missing steps, wrong order, leaked secrets, forbidden network, invalid arguments, budget overruns) plus three debugging capabilities (witness, repro, shrink).
- Add `docs/what_trajectly_catches.md` -- deep-dive walkthrough of all six failure categories with real arena examples, contract YAML, violation outputs, and the full repro+shrink debug loop.
- Add `docs/contract_catalog.md` -- reference for all six contract dimensions (tools, sequence, network, data-leak, args, budgets) with "Without this" problem statements.
- Update `docs/ci_github_actions.md` to use survival-arena examples instead of procurement-approval-demo references.

## Test plan

- [ ] Verify all docs render correctly on GitHub
- [ ] Confirm no broken links to survival-arena or docs cross-references
- [ ] CI passes

Made with [Cursor](https://cursor.com)