### PR TITLE
docs: fix action version and quickstart instructions from audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Uses committed fixtures -- no API keys required.
 git clone https://github.com/trajectly/trajectly-survival-arena.git
 cd trajectly-survival-arena
 python3.11 -m venv .venv && source .venv/bin/activate
+python -m pip install --upgrade pip
 pip install -r requirements.txt
 python -m trajectly init
 
@@ -101,7 +102,7 @@ No log hunting. No guesswork. No LLM calls for evaluation.
 
 ## Use This In Your Project
 
-1. Add one `.agent.yaml` spec:
+1. Add one `.agent.yaml` spec (save as `specs/my-agent.agent.yaml`):
 
 ```yaml
 schema_version: "0.4"
@@ -114,7 +115,7 @@ contracts:
   config: contracts/my-agent.contracts.yaml
 ```
 
-2. Add one `.contracts.yaml` policy:
+2. Add one `.contracts.yaml` policy (save as `contracts/my-agent.contracts.yaml`):
 
 ```yaml
 version: v1
@@ -148,7 +149,7 @@ python -m trajectly report --pr-comment > trajectly_pr_comment.md
 GitHub Actions:
 
 ```yaml
-- uses: trajectly/trajectly-action@v1.0.1
+- uses: trajectly/trajectly-action@v1.0.2
   with:
     spec_glob: "specs/*.agent.yaml"
     project_root: "."

--- a/docs/ci_github_actions.md
+++ b/docs/ci_github_actions.md
@@ -1,7 +1,7 @@
 # CI: GitHub Actions
 
 The canonical Trajectly GitHub Action is:
-`trajectly/trajectly-action@v1.0.1`
+`trajectly/trajectly-action@v1.0.2`
 
 It wraps CLI commands and CI plumbing only. TRT evaluation remains in Python code.
 
@@ -18,18 +18,20 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: trajectly/trajectly-action@v1.0.1
+      - uses: trajectly/trajectly-action@v1.0.2
         with:
           spec_glob: "specs/challenges/*.agent.yaml"
           project_root: "."
 ```
+
+**Prerequisite**: Your repository must have committed baselines under `.trajectly/baselines/`. Record them first with `python -m trajectly record` (see [Guide](trajectly_guide.md)).
 
 ## Use from another repository
 
 If your workflow runs on pull requests and you want comment updates:
 
 ```yaml
-- uses: trajectly/trajectly-action@v1.0.1
+- uses: trajectly/trajectly-action@v1.0.2
   with:
     spec_glob: "specs/challenges/*.agent.yaml"
     project_root: "."


### PR DESCRIPTION
## Summary
- Update `trajectly-action` references from `@v1.0.1` to `@v1.0.2` in README and CI guide
- Add `python -m pip install --upgrade pip` to quickstart
- Add baseline prerequisite note to `ci_github_actions.md` for new projects
- Add file-save instructions in "Use This In Your Project" section of README

## Context
Found during a full documentation audit simulating a new user following all instructions end-to-end.

## Test plan
- [x] Verified quickstart instructions work via fresh clone in `/tmp`
- [x] All `v1.0.2` references match the latest release

Made with [Cursor](https://cursor.com)