### PR TITLE
docs: fix issues found in second documentation audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ CONTRACT_SEQUENCE_REQUIRE_BEFORE_VIOLATED — expected=reserve_room before send_
 The summary looks clean but the outbound tool-call payload contains a secret pattern. Trajectly scans outbound arguments against regex patterns declared in the contract.
 
 ```text
-DATA_LEAK_SECRET_PATTERN — pattern=sk_live_[A-Za-z0-9]+ — witness=4
+DATA_LEAK_SECRET_PATTERN — pattern=sk_live_[A-Za-z0-9_]+ — witness=4
 ```
 
 ### Forbidden network access

--- a/docs/ci_github_actions.md
+++ b/docs/ci_github_actions.md
@@ -31,12 +31,25 @@ jobs:
 If your workflow runs on pull requests and you want comment updates:
 
 ```yaml
-- uses: trajectly/trajectly-action@v1.0.2
-  with:
-    spec_glob: "specs/challenges/*.agent.yaml"
-    project_root: "."
-    comment_pr: "true"
+name: Agent Regression Tests
+on: [pull_request]
+
+jobs:
+  trajectly:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trajectly/trajectly-action@v1.0.2
+        with:
+          spec_glob: "specs/challenges/*.agent.yaml"
+          project_root: "."
+          comment_pr: "true"
 ```
+
+> `pull-requests: write` is required for PR comment updates.
 
 Recommendation:
 - use a pinned ref (`@vX.Y.Z` or a commit SHA) for stable CI behavior

--- a/docs/trajectly_guide.md
+++ b/docs/trajectly_guide.md
@@ -17,7 +17,7 @@ For command and schema lookup, use [Reference](trajectly_reference.md).
 - [2) Core concepts](#2-core-concepts)
 - [3) TRT algorithm](#3-trt-algorithm)
 - [4) Daily workflow](#4-daily-workflow)
-- [10) Troubleshooting](#10-troubleshooting)
+- [5) Troubleshooting](#5-troubleshooting)
 
 ---
 
@@ -228,7 +228,7 @@ python -m trajectly baseline promote v2 specs/challenges/procurement-chaos.agent
 
 ---
 
-## 10) Troubleshooting
+## 5) Troubleshooting
 
 Most failures fall into three buckets:
 - fixture/replay mismatch

--- a/docs/trajectly_reference.md
+++ b/docs/trajectly_reference.md
@@ -11,15 +11,15 @@ For onboarding and troubleshooting, use [Guide](trajectly_guide.md).
 
 ## Table of contents
 
-- [5) CLI reference](#5-cli-reference)
-- [6) Spec reference](#6-spec-reference)
-- [7) SDK reference](#7-sdk-reference)
-- [8) Trace schema reference](#8-trace-schema-reference)
-- [9) Contracts reference](#9-contracts-reference)
+- [1) CLI reference](#1-cli-reference)
+- [2) Spec reference](#2-spec-reference)
+- [3) SDK reference](#3-sdk-reference)
+- [4) Trace schema reference](#4-trace-schema-reference)
+- [5) Contracts reference](#5-contracts-reference)
 
 ---
 
-## 5) CLI reference
+## 1) CLI reference
 
 The command surface below reflects current `python -m trajectly --help` workflow.
 
@@ -184,7 +184,7 @@ python -m trajectly baseline update --auto --project-root .
 
 ---
 
-## 6) Spec reference
+## 2) Spec reference
 
 Trajectly specs are `.agent.yaml` files.
 
@@ -254,7 +254,7 @@ Merge semantics:
 
 ---
 
-## 7) SDK reference
+## 3) SDK reference
 
 Trajectly supports two SDK styles that share the same runtime instrumentation path.
 
@@ -376,7 +376,7 @@ Framework adapters in `trajectly.sdk.adapters` include:
 
 ---
 
-## 8) Trace schema reference
+## 4) Trace schema reference
 
 Trajectly stores traces as JSONL (one event per line).
 
@@ -426,7 +426,7 @@ Note: spec schema version (`0.4`) and trace schema version (`v1`) are intentiona
 
 ---
 
-## 9) Contracts reference
+## 5) Contracts reference
 
 Contracts are under `contracts:` in spec YAML.
 
@@ -499,4 +499,4 @@ contracts:
 
 ---
 
-For troubleshooting and failure-recovery workflow, use [Guide: 10) Troubleshooting](trajectly_guide.md#10-troubleshooting).
+For troubleshooting and failure-recovery workflow, use [Guide: 5) Troubleshooting](trajectly_guide.md#5-troubleshooting).

--- a/docs/what_trajectly_catches.md
+++ b/docs/what_trajectly_catches.md
@@ -124,7 +124,7 @@ data_leak:
 - `secret-karaoke`: regression
   - trt: `FAIL` (witness=4)
   - code: DATA_LEAK_SECRET_PATTERN
-  - detail: pattern=sk_live_[A-Za-z0-9]+
+  - detail: pattern=sk_live_[A-Za-z0-9_]+
 ```
 
 Trajectly scans outbound tool-call arguments for regex-matched secret patterns. Without this, an agent can pass every test while quietly exfiltrating credentials.
@@ -311,6 +311,7 @@ All examples above are runnable in the [trajectly-survival-arena](https://github
 git clone https://github.com/trajectly/trajectly-survival-arena.git
 cd trajectly-survival-arena
 python3.11 -m venv .venv && source .venv/bin/activate
+python -m pip install --upgrade pip
 pip install -r requirements.txt
 python -m trajectly init
 


### PR DESCRIPTION
## Summary
- Fix secret regex pattern in violation output examples (`sk_live_[A-Za-z0-9]+` → `sk_live_[A-Za-z0-9_]+`) in README and what_trajectly_catches.md
- Add complete workflow YAML with `pull-requests: write` permission to the `comment_pr: "true"` example in ci_github_actions.md (previously just a step snippet without permissions)
- Add missing `python -m pip install --upgrade pip` to what_trajectly_catches.md "Try it" quickstart
- Renumber Guide sections to 1-5 and Reference sections to 1-5 for standalone readability (previously used split numbering: Guide 1-4,10 / Reference 5-9)

## Context
Found during a second comprehensive documentation audit simulating a new user.

## Test plan
- [x] Verified all commands via fresh clone E2E run
- [x] Confirmed actual CLI violation output includes underscore in regex pattern
- [x] Cross-referenced all anchor links between Guide and Reference

Made with [Cursor](https://cursor.com)