### PR TITLE
Add missing PR comment report test

### DIFF
--- a/tests/integration/test_cli_diff_report.py
+++ b/tests/integration/test_cli_diff_report.py
@@ -71,6 +71,14 @@ def test_cli_report_pr_comment_output(tmp_path: Path) -> None:
     assert "`demo`" in result.stdout
 
 
+def test_cli_report_pr_comment_missing_latest_file_returns_error(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["report", "--project-root", str(tmp_path), "--pr-comment"])
+
+    assert result.exit_code == 2
+    assert "Latest report not found" in result.output
+    assert "Run `python -m trajectly run` first to generate a report." in result.output
+
+
 def test_cli_report_rejects_json_with_pr_comment(tmp_path: Path) -> None:
     result = runner.invoke(app, ["report", "--project-root", str(tmp_path), "--json", "--pr-comment"])
     assert result.exit_code == 2


### PR DESCRIPTION
## Summary
- add integration coverage for `report --pr-comment` when `latest.json` is missing
- assert the command exits with code `2`
- assert the helpful error text tells the user to run `python -m trajectly run` first

## Testing
- `pytest tests/integration/test_cli_diff_report.py -q`
- `git diff --check`

Closes #45.