### PR TITLE
Assert CLI success messages in integration flow tests

### DIFF
--- a/tests/integration/test_cli_flow.py
+++ b/tests/integration/test_cli_flow.py
@@ -67,6 +67,7 @@ budget_thresholds:
         ["record", str(spec), "--project-root", str(tmp_path)],
     )
     assert record_result.exit_code == 0
+    assert "Recorded 1 spec(s) successfully" in record_result.stdout
 
     run_result = runner.invoke(
         app,
@@ -267,6 +268,7 @@ env:
         ["baseline", "update", str(spec), "--project-root", str(tmp_path)],
     )
     assert update_result.exit_code == 0
+    assert "Updated baseline for 1 spec(s)" in update_result.stdout
 
     clean_after_update = runner.invoke(app, ["run", str(spec), "--project-root", str(tmp_path)])
     assert clean_after_update.exit_code == 0
@@ -326,6 +328,7 @@ add(1, 2)
         ["baseline", "create", str(spec), "--name", "v2", "--project-root", str(tmp_path)],
     )
     assert create_v2.exit_code == 0
+    assert "Created baseline version" in create_v2.stdout
 
     run_v2 = runner.invoke(app, ["run", str(spec), "--project-root", str(tmp_path), "--baseline", "v2"])
     assert run_v2.exit_code == 0


### PR DESCRIPTION
## Summary
- lock in the success message for `record`
- lock in the success message for `baseline update`
- lock in the success message for `baseline create`

## Testing
- `PATH=/tmp/trajectly-test-bin:$PATH pytest tests/integration/test_cli_flow.py -q`
- `git diff --check`

Note: this environment has `python3` but no `python`, so I used a local shim in `/tmp/trajectly-test-bin/python` to satisfy the existing integration fixtures that execute `python agent.py`.

Closes #53