### PR TITLE
Add record no-targets integration test

### DIFF
--- a/tests/integration/test_cli_flow.py
+++ b/tests/integration/test_cli_flow.py
@@ -126,6 +126,14 @@ def test_record_auto_returns_error_when_no_specs_discovered(tmp_path: Path) -> N
     assert "No .agent.yaml specs discovered" in result.output
 
 
+def test_record_without_targets_and_without_auto_returns_error(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["record", "--project-root", str(tmp_path)])
+
+    assert result.exit_code == 2
+    assert "No targets provided" in result.output
+    assert "Pass spec/glob targets or use --auto" in result.output
+
+
 def test_record_blocks_baseline_write_in_ci_without_override(tmp_path: Path) -> None:
     script = tmp_path / "agent.py"
     _write_script(


### PR DESCRIPTION
## Summary
- add integration coverage for running `record` with no targets and without `--auto`
- assert the command exits with code `2`
- assert the user-facing validation message explains how to proceed

## Testing
- `PATH=/tmp/trajectly-test-bin:$PATH pytest tests/integration/test_cli_flow.py -q -k record`
- `git diff --check`

Note: this environment has `python3` but not `python`, so I used a local shim in `/tmp/trajectly-test-bin/python` for the existing integration fixtures that execute `python agent.py`.

Closes #46