### PR TITLE
Add baseline list filter integration test

### DIFF
--- a/tests/integration/test_cli_flow.py
+++ b/tests/integration/test_cli_flow.py
@@ -362,6 +362,16 @@ add(1, 2)
     assert "v1" in entries["versioned"]["versions"]
     assert "v2" in entries["versioned"]["versions"]
 
+    listed_by_slug = runner.invoke(app, ["baseline", "list", "versioned", "--project-root", str(tmp_path)])
+    assert listed_by_slug.exit_code == 0
+    listed_by_slug_payload = json.loads(listed_by_slug.stdout)
+    assert listed_by_slug_payload["specs"] == [entries["versioned"]]
+
+    listed_by_path = runner.invoke(app, ["baseline", "list", str(spec), "--project-root", str(tmp_path)])
+    assert listed_by_path.exit_code == 0
+    listed_by_path_payload = json.loads(listed_by_path.stdout)
+    assert listed_by_path_payload["specs"] == [entries["versioned"]]
+
     report_payload = json.loads((tmp_path / ".trajectly" / "reports" / "versioned.json").read_text(encoding="utf-8"))
     trt_payload = report_payload["trt_v03"]
     assert trt_payload["baseline_version"] == "v2"


### PR DESCRIPTION
## Summary
- add integration coverage for `baseline list` filtering by slug
- add integration coverage for `baseline list` filtering by spec path
- keep the new assertions inside the existing baseline-versioning integration fixture

## Testing
- `PATH=/tmp/trajectly-test-bin:$PATH pytest tests/integration/test_cli_flow.py -q -k baseline`
- `git diff --check`

Note: this environment has `python3` but not `python`, so I used a local shim in `/tmp/trajectly-test-bin/python` for the existing integration fixtures that execute `python agent.py`.

Closes #47