### PR TITLE
Clarify CLI, SDK, and evaluation API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ python -m trajectly repro
 python -m trajectly shrink
 ```
 
+## How You Use Trajectly
+
+Trajectly exposes three public surfaces:
+
+### CLI
+
+The default workflow for most users. Use the CLI to record baselines, run checks, inspect reports, reproduce failures, and shrink traces.
+
+### SDK
+
+Use the SDK when you want Trajectly to instrument your agent code directly.
+
+Two SDK styles are supported:
+- Decorators: `tool`, `llm_call`, `agent_step`
+- Declarative graph: `trajectly.App`
+
+### Programmatic Evaluation API
+
+Use this when you already have trajectory events and want to evaluate them inside your own Python service, backend, or platform integration without shelling out to the CLI.
+
+Most users should start with the CLI and, when needed, the SDK. The programmatic evaluation API is mainly for embedding Trajectly into other systems.
+
 ## What Trajectly Catches
 
 Six categories of silent failure that correct-looking output can hide.
@@ -164,9 +186,9 @@ See [trajectly-action](https://github.com/trajectly/trajectly-action) for full C
 
 For platform ingestion, `python -m trajectly sync` uploads the latest run report plus portable execution trajectories to a Trajectly-compatible server endpoint. The request contract is documented in [docs/platform_sync_protocol.md](docs/platform_sync_protocol.md).
 
-## Python API
+## Programmatic Evaluation API
 
-For platform or server integrations, use the stable import-safe evaluation API:
+For platform, backend, or advanced integrations, use the stable import-safe evaluation API. This is the programmatic evaluation surface, not the SDK instrumentation layer:
 
 ```python
 from pathlib import Path
@@ -193,7 +215,7 @@ if not verdict.passed:
 
 If you omit `baseline_events`, Trajectly evaluates execution contracts without requiring CLI baseline orchestration. Provide `baseline_events` when you want refinement checks to participate in the verdict.
 
-The supported Phase 1 import boundary for platform code is documented in
+The supported Phase 1 import boundary for platform/server code is documented in
 [docs/platform_api_surface.md](docs/platform_api_surface.md).
 
 ## Try Merge or Die
@@ -207,9 +229,9 @@ Eight arena scenarios covering all six failure categories. Run them, break them,
 - [Guide](docs/trajectly_guide.md) -- onboarding, core concepts, TRT algorithm
 - [What Trajectly Catches](docs/what_trajectly_catches.md) -- six failure categories with full examples
 - [Contract Catalog](docs/contract_catalog.md) -- reference for all six contract dimensions
-- [Reference](docs/trajectly_reference.md) -- CLI, spec schema, SDK, trace schema
+- [Reference](docs/trajectly_reference.md) -- CLI, spec schema, SDK, programmatic evaluation API, trace schema
 - [CI: GitHub Actions](docs/ci_github_actions.md) -- action inputs, execution order, artifacts
-- [Platform API Surface](docs/platform_api_surface.md) -- supported imports and compatibility contract for `trajectly-platform`
+- [Platform API Surface](docs/platform_api_surface.md) -- stable import boundary for platform/server integrations
 - [Platform Sync Protocol](docs/platform_sync_protocol.md) -- HTTP contract for `trajectly sync`
 - [Architecture (maintainers)](docs/architecture.md)
 

--- a/docs/platform_api_surface.md
+++ b/docs/platform_api_surface.md
@@ -5,9 +5,14 @@ is allowed to rely on. Everything listed here is treated as a compatibility
 contract for the `0.4.x` line. Imports outside this document are considered
 internal implementation details unless another document says otherwise.
 
+Use this document when embedding Trajectly into backend, service, or platform
+code. It describes the stable programmatic evaluation API, not the SDK
+instrumentation layer. Most application developers should start with the CLI
+and, when needed, the SDK.
+
 ## Supported Imports
 
-Prefer the explicit core import path in server code:
+Prefer the explicit core import path in server or platform code:
 
 ```python
 from trajectly.core import Trajectory, Verdict, Violation, evaluate

--- a/docs/trajectly_reference.md
+++ b/docs/trajectly_reference.md
@@ -4,18 +4,23 @@ This is the canonical lookup reference for:
 - CLI commands
 - spec schema
 - SDK interfaces
+- programmatic evaluation API
 - trace schema
 - contracts
 
 For onboarding and troubleshooting, use [Guide](trajectly_guide.md).
+Most users start with the CLI and, when needed, the SDK. The programmatic
+evaluation API is for embedding Trajectly into backend, service, or platform
+code that already has trajectory events.
 
 ## Table of contents
 
 - [1) CLI reference](#1-cli-reference)
 - [2) Spec reference](#2-spec-reference)
 - [3) SDK reference](#3-sdk-reference)
-- [4) Trace schema reference](#4-trace-schema-reference)
-- [5) Contracts reference](#5-contracts-reference)
+- [4) Programmatic evaluation API reference](#4-programmatic-evaluation-api-reference)
+- [5) Trace schema reference](#5-trace-schema-reference)
+- [6) Contracts reference](#6-contracts-reference)
 
 ---
 
@@ -277,7 +282,9 @@ Merge semantics:
 
 ## 3) SDK reference
 
-Trajectly supports two SDK styles that share the same runtime instrumentation path.
+Trajectly supports two SDK styles that share the same runtime instrumentation
+path. Use the SDK when you want Trajectly to instrument your agent code
+directly.
 
 ### Choosing an SDK style
 
@@ -397,7 +404,64 @@ Framework adapters in `trajectly.sdk.adapters` include:
 
 ---
 
-## 4) Trace schema reference
+## 4) Programmatic evaluation API reference
+
+Use the programmatic evaluation API when you already have trajectory events and
+want to evaluate them inside your own Python process without shelling out to the
+CLI.
+
+This API does not instrument your agent code. For instrumentation, use the SDK
+above.
+
+### Supported imports
+
+```python
+from trajectly.core import Trajectory, Verdict, Violation, evaluate
+```
+
+The top-level mirror remains supported for the same symbols:
+
+```python
+from trajectly import Trajectory, Verdict, Violation, evaluate
+```
+
+### Example
+
+```python
+from pathlib import Path
+
+from trajectly.core import Trajectory, evaluate
+from trajectly.events import make_event
+
+trajectory = Trajectory(
+    events=[
+        make_event(
+            event_type="tool_called",
+            seq=1,
+            run_id="service-run",
+            rel_ms=1,
+            payload={"tool_name": "search", "input": {"args": [], "kwargs": {}}},
+        )
+    ]
+)
+
+verdict = evaluate(trajectory, Path("specs/my-agent.agent.yaml"))
+if not verdict.passed:
+    print(verdict.primary_violation)
+```
+
+### When to use it
+
+- backend or platform services that already collect trajectory events
+- custom integrations that want a Python return object instead of CLI output
+- server-side evaluation without spawning `python -m trajectly ...`
+
+For the stable compatibility contract used by `trajectly-platform`, see
+[Platform API Surface](platform_api_surface.md).
+
+---
+
+## 5) Trace schema reference
 
 Trajectly stores traces as JSONL (one event per line).
 
@@ -480,7 +544,7 @@ Portable JSON helpers:
 
 ---
 
-## 5) Contracts reference
+## 6) Contracts reference
 
 Contracts are under `contracts:` in spec YAML.
 


### PR DESCRIPTION
## Summary
- clarify the three public Trajectly surfaces in the README
- rename the user-facing "Python API" section to "Programmatic Evaluation API"
- add a dedicated programmatic evaluation API section in the reference docs

## Testing
- docs only; verified updated headings and cross-references locally