### PR TITLE
Improve docs for use cases and CI positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 Deterministic regression testing for AI agents.
 
 The answer looked fine. The behavior wasn't. An agent that skips approval, leaks a secret, or calls a forbidden domain can still produce a perfectly worded final answer. Trajectly catches the behavioral regression and tells you *exactly where it broke*.
+Record once against live behavior, then replay committed fixtures deterministically in CI with no API key.
 
 ## Install
 
@@ -62,13 +63,17 @@ Most users should start with the CLI and, when needed, the SDK. The programmatic
 ## What Trajectly Catches
 
 Six categories of silent failure that correct-looking output can hide.
+Trajectly checks execution-path behavior, not final-answer quality: which tools ran, with what arguments, in what order, and across which data boundaries.
+The examples below are simplified report snippets with labeled fields.
 
 ### Missing steps
 
 An agent skips a required step but the answer reads fine. Trajectly extracts a tool-call skeleton from the baseline and verifies it appears as a subsequence in the current trace. Missing calls break the skeleton.
 
 ```text
-REFINEMENT_BASELINE_CALL_MISSING — missing_call=route_for_approval — witness=6
+violation: REFINEMENT_BASELINE_CALL_MISSING
+detail: missing_call=route_for_approval
+witness: 6
 ```
 
 ### Wrong order
@@ -76,7 +81,9 @@ REFINEMENT_BASELINE_CALL_MISSING — missing_call=route_for_approval — witness
 The right tools called in the wrong sequence. `require_before` says "A must happen before B" without locking exact positions, so the agent can evolve without breaking the ordering rule.
 
 ```text
-CONTRACT_SEQUENCE_REQUIRE_BEFORE_VIOLATED — expected=reserve_room before send_invite — witness=4
+violation: CONTRACT_SEQUENCE_REQUIRE_BEFORE_VIOLATED
+detail: expected=reserve_room before send_invite
+witness: 4
 ```
 
 ### Leaked secrets
@@ -84,7 +91,9 @@ CONTRACT_SEQUENCE_REQUIRE_BEFORE_VIOLATED — expected=reserve_room before send_
 The summary looks clean but the outbound tool-call payload contains a secret pattern. Trajectly scans outbound arguments against regex patterns declared in the contract.
 
 ```text
-DATA_LEAK_SECRET_PATTERN — pattern=sk_live_[A-Za-z0-9_]+ — witness=4
+violation: DATA_LEAK_SECRET_PATTERN
+detail: pattern=sk_live_[A-Za-z0-9_]+
+witness: 4
 ```
 
 ### Forbidden network access
@@ -92,7 +101,8 @@ DATA_LEAK_SECRET_PATTERN — pattern=sk_live_[A-Za-z0-9_]+ — witness=4
 The agent reports success but contacted a domain outside the allowlist. The network contract defaults to deny-all and whitelists specific domains.
 
 ```text
-NETWORK_DOMAIN_DENIED — witness=2
+violation: NETWORK_DOMAIN_DENIED
+witness: 2
 ```
 
 ### Invalid arguments
@@ -100,7 +110,8 @@ NETWORK_DOMAIN_DENIED — witness=2
 A tool call completes but an argument violates its format. Argument contracts validate required keys, types, numeric bounds, regex patterns, and enum values on every call.
 
 ```text
-CONTRACT_ARGS_REGEX_VIOLATION — witness=6
+violation: CONTRACT_ARGS_REGEX_VIOLATION
+witness: 6
 ```
 
 ### Budget overruns
@@ -108,8 +119,17 @@ CONTRACT_ARGS_REGEX_VIOLATION — witness=6
 Identical output, but twice the tool calls or tokens. Budget thresholds gate execution cost at the spec level.
 
 ```text
-budget_breach — max_tool_calls exceeded
+classification: budget_breach
+detail: max_tool_calls exceeded
 ```
+
+## Common Use Cases
+
+Trajectly is a good fit for agents that can look correct while doing the wrong thing at runtime.
+
+- **Support agents** -- keep read-only lookups read-only, require approval for MFA resets, ensure audit trails, and prevent PII leakage. See the [support agent case study](https://www.trajectly.dev/case-study/testing-the-support-agent).
+- **Approval-driven workflows** -- procurement, finance, HR, and IT operations agents where required steps, ordering, and one-time approvals matter.
+- **Tool-using copilots and RAG agents** -- validate tool arguments after model or prompt changes, block forbidden tools or domains, and catch hidden cost regressions.
 
 ## How You Debug Failures
 
@@ -125,41 +145,58 @@ No log hunting. No guesswork. No LLM calls for evaluation.
 
 ## Use This In Your Project
 
-1. Add one `.agent.yaml` spec (save as `specs/my-agent.agent.yaml`):
+1. Add one `.agent.yaml` spec (save as `specs/support-agent-mfa-reset.agent.yaml`):
 
 ```yaml
 schema_version: "0.4"
-name: "my-agent"
-command: "python -m my_agent.runner"
+name: "support-agent-mfa-reset"
+command: "python -m support_agent.runner"
 workdir: .
 strict: true
 fixture_policy: by_hash
+budget_thresholds:
+  max_tool_calls: 6
+  max_tokens: 800
 contracts:
-  config: contracts/my-agent.contracts.yaml
+  config: contracts/support-agent.contracts.yaml
 ```
 
-2. Add one `.contracts.yaml` policy (save as `contracts/my-agent.contracts.yaml`):
+2. Add one `.contracts.yaml` policy (save as `contracts/support-agent.contracts.yaml`):
 
 ```yaml
 version: v1
 tools:
-  allow: [fetch_context, create_reply]
+  allow: [draft_mfa_reset_request, request_human_approval, log_audit_event]
+  deny: [delete_user, disable_guardrails]
+args:
+  draft_mfa_reset_request:
+    required_keys: [account_id]
+    fields:
+      account_id:
+        type: string
+        regex: "^ACME-"
 sequence:
-  require: [fetch_context, create_reply]
+  require: [tool:draft_mfa_reset_request, tool:request_human_approval]
+  at_most_once: [tool:request_human_approval]
+  eventually: [tool:log_audit_event]
+data_leak:
+  deny_pii_outbound: true
 ```
 
 3. Record, gate, debug:
 
 ```bash
 python -m trajectly init
-python -m trajectly record specs/my-agent.agent.yaml --project-root .
-python -m trajectly run specs/my-agent.agent.yaml --project-root .
+python -m trajectly record specs/support-agent-mfa-reset.agent.yaml --project-root .
+python -m trajectly run specs/support-agent-mfa-reset.agent.yaml --project-root .
 python -m trajectly report
 python -m trajectly repro
 python -m trajectly shrink
 ```
 
 ## CI Integration
+
+Trajectly is the fast deterministic gate on every pull request. Record baselines locally against live behavior, commit them, then let CI replay the fixtures offline on every run. Broader live evals can run later on `main`, release branches, or scheduled jobs.
 
 Any CI:
 

--- a/docs/ci_github_actions.md
+++ b/docs/ci_github_actions.md
@@ -5,6 +5,17 @@ The canonical Trajectly GitHub Action is:
 
 It wraps CLI commands and CI plumbing only. TRT evaluation remains in Python code.
 
+## Recommended pipeline shape
+
+Use Trajectly as the fast deterministic gate on every pull request:
+
+1. Record baselines locally against live behavior with `python -m trajectly record`.
+2. Commit `.trajectly/baselines/` and `.trajectly/fixtures/`.
+3. Run `trajectly/trajectly-action` on every PR to replay those fixtures offline.
+4. Run slower live evals separately on `main`, release branches, or scheduled workflows.
+
+This split keeps Trajectly in the blocking CI tier because replay mode needs no API key, makes no live model calls, and reproduces the same failures every time.
+
 ## Minimal workflow
 
 ```yaml
@@ -25,6 +36,7 @@ jobs:
 ```
 
 **Prerequisite**: Your repository must have committed baselines under `.trajectly/baselines/`. Record them first with `python -m trajectly record` (see [Guide](trajectly_guide.md)).
+Commit the matching `.trajectly/fixtures/` directory too; replay mode depends on both artifacts.
 
 ## Use from another repository
 
@@ -128,6 +140,7 @@ python -m trajectly report --pr-comment > trajectly_pr_comment.md
 Expected behavior:
 - `run` exits `0` for clean runs, `1` for regressions, `2` for config/tooling errors.
 - `trajectly_pr_comment.md` contains a markdown summary table for PR comments.
+- the run is deterministic because fixtures are replayed instead of calling live tools or models
 
 Upload `.trajectly/**` as artifacts with your CI provider.
 

--- a/docs/contract_catalog.md
+++ b/docs/contract_catalog.md
@@ -6,6 +6,40 @@ All examples reference real scenarios from the [Merge or Die arena](https://gith
 
 ---
 
+## Common policy recipes
+
+These compact patterns map the contract dimensions to common production agent use cases.
+
+### Support agent: read-only lookup
+
+Use `tools.deny`, `side_effects.deny_write_tools`, and `args` together when a support agent should answer a lookup without mutating anything.
+
+Typical checks:
+- only allow lookup tools for the scenario
+- deny write tools such as escalation or account mutation
+- require identifiers such as `invoice_id` or `ticket_id` to match a regex
+
+### Approval-driven workflow
+
+Use `sequence.require`, `require_before`, `at_most_once`, and `eventually` when approvals, audits, and one-time actions matter.
+
+Typical checks:
+- approval must occur before the write action
+- approval cannot loop or fire twice
+- an audit event must eventually appear in the trace
+
+### Tool-using copilot or RAG agent
+
+Use `args`, `network`, `data_leak`, and `budget_thresholds` when prompts or model changes can silently alter tool usage.
+
+Typical checks:
+- tool arguments stay well-formed after prompt/model changes
+- outbound domains stay on an allowlist
+- PII and secrets do not cross tool boundaries
+- tool-call and token budgets do not drift upward
+
+---
+
 ## 1. Tools (allow / deny)
 
 Controls which tool calls are permitted during execution.

--- a/docs/trajectly_guide.md
+++ b/docs/trajectly_guide.md
@@ -94,6 +94,16 @@ Replace `specs/challenges/procurement-chaos.agent.yaml` with your own spec path 
 
 ## 2) Core concepts
 
+### Where Trajectly fits
+
+Trajectly is the execution-path layer in an agent testing stack.
+
+- Unit and integration tests verify code paths, tool implementations, and deterministic orchestration.
+- Trajectly verifies what the agent actually did at runtime: tool usage, argument formats, ordering, data boundaries, and cost ceilings.
+- Scenario evals verify answer quality, refusal quality, and broader model behavior.
+
+That split matters because an agent can return a correct-looking final answer while still skipping approval, leaking PII into a tool call, or taking a more expensive path.
+
 ### Baseline
 
 A baseline is the known-good behavior for a spec. Trajectly stores baseline traces plus fixtures for deterministic replay.
@@ -103,6 +113,7 @@ Baselines are explicit, versioned behavior decisions. Future runs compare agains
 ### Replay
 
 In replay mode, tool and LLM calls are matched against fixtures and returned deterministically. This removes online nondeterminism from regression checks.
+The usual workflow is: record once against live behavior, commit the baseline and fixtures, then replay them offline in CI without an API key.
 
 ### Contracts
 
@@ -192,6 +203,8 @@ Record from known-good behavior:
 python -m trajectly record specs/challenges/procurement-chaos.agent.yaml --project-root .
 ```
 
+This step is the only part that needs live behavior. It captures the baseline trace plus the fixtures needed to replay the same interactions later.
+
 ### Validate changes
 
 Run gate + report:
@@ -200,6 +213,8 @@ Run gate + report:
 python -m trajectly run specs/challenges/*.agent.yaml --project-root .
 python -m trajectly report
 ```
+
+`run` replays the committed fixtures and evaluates refinement plus contracts deterministically. This is the command most teams use as the blocking CI gate on every pull request.
 
 Single-spec iteration example:
 

--- a/docs/what_trajectly_catches.md
+++ b/docs/what_trajectly_catches.md
@@ -4,6 +4,13 @@ Trajectly enforces six categories of behavioral contract and provides three debu
 
 Every example below uses committed fixtures and runs without API keys.
 
+These failure classes show up in real teams too:
+- support agents that must stay read-only until approval is granted
+- approval-driven workflows in procurement, finance, HR, and IT
+- tool-using copilots and RAG agents that can drift in arguments, network reach, or cost
+
+For a concrete end-to-end example, see the published [support-agent case study](https://www.trajectly.dev/case-study/testing-the-support-agent).
+
 ---
 
 ## Six categories of silent failure


### PR DESCRIPTION
## Summary
- add use-case framing and support-agent case study links in the README and docs
- clarify that Trajectly is the execution-path testing layer and highlight deterministic fixture replay
- add practical CI and contract guidance for common agent patterns

## Testing
- not run (docs only)